### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,14 @@ name: Build
 on:
   push:
     branches:
-      - 'main'
+      - main
+      - next
+      - next-major
+      - beta
+      - alpha
+      - "[0-9]+.[0-9]+.x"
+      - "[0-9]+.x.x"
+      - "[0-9].x"
     paths-ignore:
       - '.github/**'
       - 'docs/**'


### PR DESCRIPTION
Fix the CI build to run on all branches Semantic Release is expected to run on.