### PR TITLE
feat!: remove Argus

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -71,6 +71,8 @@ function HelloWorld:SayHello()
         UIErrorsFrame:AddMessage("This is getting too hard", 1, 1, 1);
         UIErrorsFrame:AddMessage("Does this even work?!", 1, 1, 1);
         UIErrorsFrame:AddMessage("A huge change that will fix all the complaints of Wow in real time!", 1, 1, 1);
+
+        UIErrorsFrame:AddMessage("This addon is a joke...", 1, 1, 1);
     end
 end
 


### PR DESCRIPTION
Lets remove Argus from the game completely. Kiljaeden and Xelen never existed so we will need to remove the Exodar in a future release.